### PR TITLE
Add safety when receiving meta deltas

### DIFF
--- a/barometer.js
+++ b/barometer.js
@@ -74,6 +74,9 @@ function onDeltasUpdate(deltas) {
     let deltaValues = [];
 
     deltas.updates.forEach(u => {
+        if (!u.values) {
+            return;
+        }
         u.values.forEach((value) => {
             let onDeltaUpdated = SUBSCRIPTIONS.find((d) => d.path === value.path);
 


### PR DESCRIPTION
Otherwise the plugin may crash with:

```
TypeError: Cannot read properties of undefined (reading 'forEach')
```